### PR TITLE
fix inflate_calls_in_files to pass corresponding test

### DIFF
--- a/skit_calls/calls.py
+++ b/skit_calls/calls.py
@@ -275,15 +275,29 @@ def save_call(
 async def inflate_calls_in_files(
     url: str, token: str, params: dict, pages_to_read: Iterable[int]
 ) -> str:
+    """
+    Inflate calls in disk files.
+
+    :param url: The endpoint for fetching call and related data.
+    :type url: str
+    :param token: An auth token.
+    :type token: str
+    :param params: API query params.
+    :type params: dict
+    :param pages_to_read: A list of pages to read calls from (paginated API).
+    :type pages_to_read: Iterable[int]
+    :return: The path to the directory where the inflated calls are saved.
+    :rtype: str
+    """
     temp_dir = tempfile.mkdtemp()
     async with aiohttp.ClientSession(
         url, headers={**get_auth_header(token)}
     ) as session:
         for page in pages_to_read:
-            turns = await get(
+            turn = await get(
                 session, const.ROUTE__CALL, params, page=page, inflate=True
-            )
-            save_call(temp_dir, turns, breadcrumbs=params.values())
+            ) # turn will be a dict
+            save_call(temp_dir, [turn], breadcrumbs=params.values())
     return temp_dir
 
 

--- a/skit_calls/cli.py
+++ b/skit_calls/cli.py
@@ -68,7 +68,7 @@ def process_date_filters(
 
 def get_version():
     project_toml = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "pyproject.toml")
+        os.path.join(os.path.dirname(__file__), "pyproject.toml")
     )
     with open(project_toml, "r") as handle:
         project_metadata = toml.load(handle)


### PR DESCRIPTION
Currently the test case `test_inflate_calls_in_files` fails. We are expecting a list [here](https://github.com/skit-ai/skit-calls/blob/main/skit_calls/calls.py#L283), but `get` func returns a dict. This is causing the test to fail.

- Changed it to dict
- Added doct string for `inflate_calls_in_files`