### PR TITLE
auto delay and page_limit selection for paging and db connection retries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ cython_debug/
 *.sql
 *.sh
 /secrets
+.history

--- a/skit_calls/cli.py
+++ b/skit_calls/cli.py
@@ -197,10 +197,16 @@ def build_cli():
 
     parser.add_argument(
         "--delay",
+        type=float,
         help="Some queries may timeout and need some delay"
         " before a new connection is established."
         " The value should be a between (0-0.5).",
-        default=const.Q_DELAY,
+    )
+    
+    parser.add_argument(
+        "--max-turns-batch-limit",
+        type=int,
+        help="Maximum number of turns to be collected in a single batch.",
     )
 
     parser.add_argument(
@@ -233,6 +239,8 @@ def random_sample_calls(args: argparse.Namespace) -> str | pd.DataFrame:
         asr_provider=args.asr_provider,
         states=args.states,
         on_disk=args.on_disk,
+        max_turns_batch_limit=args.max_turns_batch_limit,
+        delay=args.delay,
     )
     logger.info(f"Finished in {time.time() - start:.2f} seconds")
     return maybe_df

--- a/skit_calls/data/query.py
+++ b/skit_calls/data/query.py
@@ -102,7 +102,7 @@ def gen_random_calls(
     logger.debug(f"Creating {batch_size} batches for {call_id_size} calls")
     i = 0
     with tqdm(total=batch_size, desc="Downloading calls dataset.") as pbar:
-        for i in range(0, len(call_ids), limit):
+        for i in range(0, call_id_size, limit):
             batch = call_ids[i : i + limit]
             with connect() as conn:
                 with conn.cursor(cursor_factory=NamedTupleCursor) as cursor:

--- a/skit_calls/utils.py
+++ b/skit_calls/utils.py
@@ -3,7 +3,7 @@ Module provides access to logger config, session token and package version.
 """
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 import toml
 from loguru import logger
@@ -68,3 +68,26 @@ def read_session() -> Optional[str]:
             return handle.read().strip()
     except FileNotFoundError:
         return None
+
+def optimal_paging_params(total_count: int, page_size: int, delay: int) -> Tuple[int, float]:
+    """
+    Calculate optimal page size and delay value for a given total call count.
+    """
+    # if total_count <= 500
+    # delay = 0.2 and page_size = 3000
+
+    # if total_count = 2000
+    # delay = 0.2 + 0.05 = 0.25 and page_size = 3000 // 1.8 = 1666
+
+    # if total_count = 20000
+    # delay = 0.25 + 0.5 = 0.3 and page_size = 1666 // 1.8 = 925
+    
+    init_call_quantity = 200
+    
+    if total_count <= 500:
+        return page_size, delay
+    while init_call_quantity < total_count:
+        init_call_quantity *= 10
+        delay += 0.05
+        page_size //= 1.8
+    return int(page_size), delay


### PR DESCRIPTION
auto selection of delay and page_limit based on required call quantity given for paging while sampling calls.

if number of requested calls is say `x`
and say max turns limit is `L`, and delay is `d`
then it should be `d = fn(x)` and `L = fn(x)`