### PR TITLE
adding template_id, flow_uuid & client_uuid for downstream studio call url generation

### DIFF
--- a/secrets.dvc
+++ b/secrets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 65f236163112bdd619c05238ab159305.dir
-  size: 4848
+- md5: a16af95fa3a59a66fb9f03890c2c10ff.dir
+  size: 5256
   nfiles: 5
   path: secrets

--- a/skit_calls/data/model.py
+++ b/skit_calls/data/model.py
@@ -178,6 +178,11 @@ class Turn:
     flow_version: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_id: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_name: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
+    flow_uuid: str = attr.ib(kw_only=True, repr=False)
+
+    template_id: str = attr.ib(kw_only=True, repr=True, converter=str)
+
+    client_uuid: str = attr.ib(kw_only=True, repr=False)
 
     asr_latency: MaybeFloat = attr.ib(
         kw_only=True, default=None, converter=float_maybestr, repr=False
@@ -233,7 +238,10 @@ class Turn:
             flow_version=record.flow_version,
             flow_id=record.flow_id,
             flow_name=record.flow_name,
+            flow_uuid=record.flow_uuid,
+            template_id=record.template_id,
             call_duration=record.call_duration,
+            client_uuid=record.client_uuid,
         )
 
     def serialize(self, _, __, value):


### PR DESCRIPTION
able to create 3 new columns for the turns namely,
* `template_id` 
* `flow_uuid`
* `client_uuid`

the `flow_uuid` and `client_uuid` are required to create studio call url, along with `call_uuid`.

Please suggest if there are any changes required etc. Else let me know if it is good for merge.