### PR TITLE
PL-1315 template_id bug fix

### DIFF
--- a/secrets.dvc
+++ b/secrets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a16af95fa3a59a66fb9f03890c2c10ff.dir
-  size: 5256
+- md5: 6337aa8cdb6bcf9ec8e78c11abbc17ce.dir
+  size: 5245
   nfiles: 5
   path: secrets


### PR DESCRIPTION
more (sensitive) details are present [here](https://vernacular-ai.atlassian.net/browse/PL-1315?focusedCommentId=57375). but the bug has been fixed. 

@nvinayvarma189 confirmed it by downloading the data from US production db using skit-calls (with the corrected query). all the turns generated are from calls whose flows are of `template_id` as requested.

the diff is in the `secrets/random_call_ids.sql`, so nothing significant to review on the git commits. i have pushed changes to dvc.

please let me know if there is anything else. if all good, let us go ahead with the review!