### PR TITLE
[QT-27] add: previous_disposition to skit-calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+0.2.53
+- add: new columns for randomly sampled calls - previous_disposition
+
 0.2.52
 - add: logs and fix function definition
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skit-calls"
-version = "0.2.52"
+version = "0.2.53"
 description = "Library to fetch calls from a given environment."
 authors = ["ltbringer <amresh.venugopal@gmail.com>"]
 license = "GPL-3.0-only"

--- a/secrets.dvc
+++ b/secrets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 2a702b2c3a91368922ea506f151c4cc9.dir
-  size: 5616
+- md5: 8a76aff28e9d32e78feeaa84de73d576.dir
+  size: 5799
   nfiles: 5
   path: secrets

--- a/skit_calls/data/model.py
+++ b/skit_calls/data/model.py
@@ -209,6 +209,7 @@ class Turn:
     asr_provider: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     call_end_status: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     disposition: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
+    previous_disposition: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     virtual_number: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_version: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_id: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
@@ -250,6 +251,7 @@ class Turn:
             call_url=call_url,
             call_type=record.call_type,
             disposition=record.disposition,
+            previous_disposition=record.previous_disposition,
             reftime=reftime,
             readable_reftime=readable_reftime,
             state=record.state,


### PR DESCRIPTION
adding a new column called `previous_disposition` from call_contexts.metadata for compliance tagging (based on call-level tagging)