### PR TITLE
[QT-131] adding blocking_disposition to the sampled turns query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+0.2.55
+- add: new columns for randomly sampled calls - blocking_disposition
+
 0.2.54
 - change: set right value for DB_HOST
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skit-calls"
-version = "0.2.54"
+version = "0.2.55"
 description = "Library to fetch calls from a given environment."
 authors = ["ltbringer <amresh.venugopal@gmail.com>"]
 license = "GPL-3.0-only"

--- a/secrets.dvc
+++ b/secrets.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 3c3a8017b3d6d830b87506a9797ba99a.dir
-  size: 5799
+- md5: 5b4e1a0d10e81d247a4eca808cc32976.dir
+  size: 5954
   nfiles: 5
   path: secrets

--- a/skit_calls/data/model.py
+++ b/skit_calls/data/model.py
@@ -210,6 +210,7 @@ class Turn:
     call_end_status: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     disposition: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     previous_disposition: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
+    blocking_disposition: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     virtual_number: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_version: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
     flow_id: MaybeString = attr.ib(kw_only=True, default=None, repr=False)
@@ -252,6 +253,7 @@ class Turn:
             call_type=record.call_type,
             disposition=record.disposition,
             previous_disposition=record.previous_disposition,
+            blocking_disposition=record.blocking_disposition,
             reftime=reftime,
             readable_reftime=readable_reftime,
             state=record.state,


### PR DESCRIPTION
adding a new column called `blocking_disposition` that is coming out FSM's call_context.
adding it as a separate column to show the true compliance checker outputs. 

relevant [JIRA](https://vernacular-ai.atlassian.net/browse/QT-130)